### PR TITLE
Always use system gtest library if available

### DIFF
--- a/src/lc-compliance/meson.build
+++ b/src/lc-compliance/meson.build
@@ -7,15 +7,14 @@ if not libevent.found()
     subdir_done()
 endif
 
-if get_option('android_platform') == 'cros'
-    libgtest = dependency('gtest', required : get_option('lc-compliance'))
+libgtest = dependency('gtest', required : get_option('lc-compliance'))
 
-    if not libgtest.found()
-        lc_compliance_enabled = false
-        subdir_done()
-    endif
+if not libgtest.found()
+    lc_compliance_enabled = false
+    subdir_done()
+endif
 
-else
+if get_option('android_platform') != 'cros'
     libgtest_sp = subproject('gtest')
     libgtest = libgtest_sp.get_variable('gtest_dep')
 endif


### PR DESCRIPTION
Recently the libcamera package stopped building on ArchLinux (https://aur.archlinux.org/packages/libcamera-git/) unless `lc-compliance` option is set to `disabled` or `android_platform` is set to `cros`, what is a bit misleading since `android` feature is not turned on.
It happens because Arch guidelines recommend to set `wrap-mode` to `nodownload` and system `gtest` library is not recongnized by meson/ninja.

Could it be that there's an extra nesting level of condition, which tests presence of "gtest" library in the system?