### PR TITLE
Specify packed attribute to union

### DIFF
--- a/include/linux/videodev2.h
+++ b/include/linux/videodev2.h
@@ -1733,7 +1733,7 @@ struct v4l2_ext_control {
 		struct v4l2_ctrl_mpeg2_picture *p_mpeg2_picture;
 		struct v4l2_ctrl_mpeg2_quantisation *p_mpeg2_quantisation;
 		void *ptr;
-	};
+	} __attribute__ ((packed));
 } __attribute__ ((packed));
 
 struct v4l2_ext_controls {


### PR DESCRIPTION
Fixes clang error: field within 'v4l2_ext_control' is less aligned
than 'v4l2_ext_control::(anonymous union

Signed-off-by: Devendra Tewari <devendra.tewari@gmail.com>