### PR TITLE
libcamera: pipeline: simple: Check converter_

### DIFF
--- a/src/libcamera/pipeline/simple/simple.cpp
+++ b/src/libcamera/pipeline/simple/simple.cpp
@@ -493,7 +493,7 @@ int SimpleCameraData::init()
 	MediaDevice *converter = pipe->converter();
 	if (converter) {
 		converter_ = ConverterFactoryBase::create(converter);
-		if (!converter_->isValid()) {
+		if (!converter_) {
 			LOG(SimplePipeline, Warning)
 				<< "Failed to create converter, disabling format conversion";
 			converter_.reset();


### PR DESCRIPTION
- If no converter is found, ConverterFactoryBase::create() returns a nullptr and !converter_->isValid() causes a segmentation fault.
- Avoid this by checking if converter_ is a nullptr.

