### PR TITLE
pipeline: uvcvideo: Drop Contoller ID check

### DIFF
--- a/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp
+++ b/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp
@@ -525,8 +525,8 @@ bool UVCCameraData::generateId()
 	while (true) {
 		std::string::size_type pos = searchPath.rfind('/');
 		if (pos <= 1) {
-			LOG(UVC, Error) << "Can not find controller ID";
-			return false;
+			LOG(UVC, Debug) << "Controller ID was not detected";
+			break;
 		}
 
 		searchPath = searchPath.substr(0, pos);


### PR DESCRIPTION
USB camera might not support any specific of_node or devicetree (on Ubuntu for instance).

Drop Controller ID check for such cases