### PR TITLE
Fix stageGain variable not initialized when optimization is enabled

### DIFF
--- a/src/ipa/libipa/exposure_mode_helper.cpp
+++ b/src/ipa/libipa/exposure_mode_helper.cpp
@@ -166,8 +166,15 @@ ExposureModeHelper::splitExposure(utils::Duration exposure) const
 		return { minShutter_, minGain_, exposure / (minShutter_ * minGain_) };
 
 	utils::Duration shutter;
-	double stageGain;
 	double gain;
+	/*
+	 * From here on all we can do is max out the shutter time, followed by
+	 * the analogue gain. If we still haven't achieved the target we send
+	 * the rest of the exposure time to digital gain. If we were given no
+	 * stages to use then set stageGain to 1.0 so that shutter time is maxed
+	 * before gain touched at all.
+	 */
+	double stageGain = 1.0;
 
 	for (unsigned int stage = 0; stage < gains_.size(); stage++) {
 		double lastStageGain = stage == 0 ? 1.0 : clampGain(gains_[stage - 1]);
@@ -196,16 +203,6 @@ ExposureModeHelper::splitExposure(utils::Duration exposure) const
 			return { shutter, gain, exposure / (shutter * gain) };
 		}
 	}
-
-	/*
-	 * From here on all we can do is max out the shutter time, followed by
-	 * the analogue gain. If we still haven't achieved the target we send
-	 * the rest of the exposure time to digital gain. If we were given no
-	 * stages to use then set stageGain to 1.0 so that shutter time is maxed
-	 * before gain touched at all.
-	 */
-	if (gains_.empty())
-		stageGain = 1.0;
 
 	shutter = clampShutter(exposure / clampGain(stageGain));
 	gain = clampGain(exposure / shutter);


### PR DESCRIPTION
In RISC-V, when optimization is enabled, it will fail to build with the following:
```
../src/ipa/libipa/exposure_mode_helper.cpp:210:52: error: ‘stageGain’ may be used uninitialized [-Werror=maybe-uninitialized]
  210 |         shutter = clampShutter(exposure / clampGain(stageGain));
      |                                           ~~~~~~~~~^~~~~~~~~~~
../src/ipa/libipa/exposure_mode_helper.cpp:169:16: note: ‘stageGain’ was declared here
  169 |         double stageGain;
      |                ^~~~~~~~~
```

According to the [gcc manual](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#Warning-Options)

For an object with automatic or allocated storage duration, if there exists a path from the function entry to a use of the object that is initialized, but there exist some other paths for which the object is not initialized, the compiler emits a warning if it cannot prove the uninitialized paths are not executed at run time.

*These warnings are only possible in optimizing compilation, because otherwise GCC does not keep track of the state of variables.*




